### PR TITLE
build: add dependency to gwt-elemental

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.vaadin.external.gwt</groupId>
+            <artifactId>gwt-elemental</artifactId>
+            <version>2.8.2.vaadin2</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.flowingcode.vaadin.addons.demo</groupId>
             <artifactId>commons-demo</artifactId>
             <version>${flowingcode.commons.demo.version}</version>


### PR DESCRIPTION
Add dependency to gwt-elemental 2.8.2.vaadin2 (which is the same version used by Vaadin 14, 23 and 24, removed in 25 https://github.com/vaadin/flow/pull/22655).
https://github.com/vaadin/flow/blob/bd93f19f62be323df85c6aad6e49a6ea3a08582d/flow-server/pom.xml#L85-L89
https://github.com/vaadin/flow/blob/61892d55df5e6ab8e1c9849ce56bee3963b86cad/flow-server/pom.xml#L73-L77
https://github.com/vaadin/flow/blob/b8f53412cf6a6404e244c3f0b79473f6a8327e65/flow-server/pom.xml#L64-L68