### PR TITLE
docs(readme): remove special configuration when using Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,16 +179,3 @@ element.addEventListener("click", event -> {
     // ...
 }).addEventData("event.detail");
 ```
-
-
-## Special configuration when using Spring
-
-By default, Vaadin Flow only includes `com/vaadin/flow/component` to be always scanned for UI components and views. For this reason, the add-on might need to be allowed in order to display correctly. 
-
-To do so, just add `com.flowingcode` to the `vaadin.allowed-packages` property in `src/main/resources/application.properties`, like:
-
-```
-vaadin.allowed-packages = com.vaadin,org.vaadin,dev.hilla,com.flowingcode
-```
- 
-More information on Spring scanning configuration [here](https://vaadin.com/docs/latest/integrations/spring/configuration/#configure-the-scanning-of-packages).


### PR DESCRIPTION
This configuration applies to Vaadin component scanning, which is not required by JsonMigrationHelper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Spring configuration section from README, including configuration examples and resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->