### PR TITLE
fix: emit AllowInert annotation on legacy client callable methods

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/jsonmigration/ClassInstrumentationUtil.java
+++ b/src/main/java/com/flowingcode/vaadin/jsonmigration/ClassInstrumentationUtil.java
@@ -429,7 +429,13 @@ final class ClassInstrumentationUtil {
               null,
               getExceptionInternalNames(method.getExceptionTypes()));
 
-      mv.visitAnnotation(Type.getDescriptor(ClientCallable.class), true);
+      mv.visitAnnotation(Type.getDescriptor(ClientCallable.class), true).visitEnd();
+      for (java.lang.annotation.Annotation annotation : method.getAnnotations()) {
+        if ("com.vaadin.flow.component.internal.AllowInert"
+            .equals(annotation.annotationType().getName())) {
+          mv.visitAnnotation(Type.getDescriptor(annotation.annotationType()), true).visitEnd();
+        }
+      }
       mv.visitCode();
 
       boolean isPrivate = Modifier.isPrivate(method.getModifiers());

--- a/src/test/java/com/flowingcode/vaadin/jsonmigration/LegacyClientCallable_AllowInert__V.java
+++ b/src/test/java/com/flowingcode/vaadin/jsonmigration/LegacyClientCallable_AllowInert__V.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * Json Migration Helper
+ * %%
+ * Copyright (C) 2025 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.jsonmigration;
+
+import com.vaadin.flow.component.internal.AllowInert;
+
+public class LegacyClientCallable_AllowInert__V extends BaseClientCallable {
+
+  @LegacyClientCallable
+  @AllowInert
+  public void test() {
+    trace();
+  }
+}

--- a/src/test/java/com/flowingcode/vaadin/jsonmigration/LegacyClientCallablesTest.java
+++ b/src/test/java/com/flowingcode/vaadin/jsonmigration/LegacyClientCallablesTest.java
@@ -20,11 +20,13 @@
 package com.flowingcode.vaadin.jsonmigration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import elemental.json.JsonValue;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import org.junit.Test;
 
@@ -344,6 +346,23 @@ public abstract class LegacyClientCallablesTest {
             .newInstance();
     invokeTestMethod(instrumented, createArrayOfJsonObject());
     assertTrue(instrumented.hasBeenTraced());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testAllowInert__V() throws Exception {
+    LegacyClientCallable_AllowInert__V instrumented =
+        instrumentClass(LegacyClientCallable_AllowInert__V.class)
+            .getDeclaredConstructor()
+            .newInstance();
+    Method testMethod = getClientCallableTestMethod(instrumented);
+    assertNotNull("instrumented method is not annotated with @ClientCallable", testMethod);
+    Class<? extends Annotation> allowInert =
+        (Class<? extends Annotation>)
+            Class.forName("com.vaadin.flow.component.internal.AllowInert");
+    assertTrue(
+        "instrumented method is not annotated with @AllowInert",
+        testMethod.isAnnotationPresent(allowInert));
   }
 
 }

--- a/src/test/java/com/vaadin/flow/component/internal/AllowInert.java
+++ b/src/test/java/com/vaadin/flow/component/internal/AllowInert.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * Json Migration Helper
+ * %%
+ * Copyright (C) 2025 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.vaadin.flow.component.internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Stub for {@code com.vaadin.flow.component.internal.AllowInert} (available in Vaadin 24+). */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+public @interface AllowInert {}


### PR DESCRIPTION
Close #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed proper finalization and propagation of internal annotations for client-callable method overrides, ensuring annotation metadata is correctly maintained during instrumentation.

* **Tests**
  * Added test coverage for annotation metadata handling in client-callable method overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->